### PR TITLE
docs: fix release build option in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ zig build test-integration   # Run integration tests only
 zig build
 
 # Release build
-zig build -Drelease-fast
+zig build -Doptimize=ReleaseFast
 
 # Cross-compilation examples
 zig build -Dtarget=x86_64-windows


### PR DESCRIPTION
This pull request updates the `README.md` to reflect a more accurate and modern usage of Zig build options.

Documentation update:

* Updated the release build command to use `-Doptimize=ReleaseFast` instead of the outdated `-Drelease-fast` in the `README.md`. This aligns with the current Zig build option naming conventions. (`[README.mdL145-R145](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L145-R145)`)