### PR TITLE
docs: fix release build option in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ zig build test-integration   # Run integration tests only
 zig build
 
 # Release build
-zig build -Drelease-fast
+zig build -Doptimize=ReleaseFast
 
 # Cross-compilation examples
 zig build -Dtarget=x86_64-windows


### PR DESCRIPTION
This pull request updates the `README.md` file to improve clarity and consistency in the build instructions. The most notable change is a modification to the release build command to use a more explicit optimization flag.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L145-R145): Updated the release build command from `zig build -Drelease-fast` to `zig build -Doptimize=ReleaseFast` for better clarity and alignment with Zig's official terminology.