### PR TITLE
feat: Increased event list size for kqueue and epoll to 1024 and reduced timeout to 10 ms

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -423,12 +423,12 @@ const UltraPoller = struct {
     
     // macOS kqueue event loop - ULTRA FAST
     fn kqueueEventLoop(self: *Self, server: *std.net.Server, config: Config) !void {
-        var eventlist: [512]std.posix.system.Kevent = undefined;
+        var eventlist: [1024]std.posix.system.Kevent = undefined;
         
         // Short timeout for responsiveness
-        var timeout = std.posix.system.timespec{ .sec = 0, .nsec = 50_000_000 }; // 50ms
+        var timeout = std.posix.system.timespec{ .sec = 0, .nsec = 10_000_000 }; // 10ms
         var changelist: [1]std.posix.system.Kevent = undefined;
-        const num_events = std.posix.system.kevent(self.poller_fd, &changelist, 0, &eventlist, 512, &timeout);
+        const num_events = std.posix.system.kevent(self.poller_fd, &changelist, 0, &eventlist, 1024, &timeout);
         
         if (num_events < 0) return error.KqueueWaitFailed;
         if (num_events == 0) return; // Timeout
@@ -445,10 +445,10 @@ const UltraPoller = struct {
     
     // Linux epoll event loop - ULTRA FAST
     fn epollEventLoop(self: *Self, server: *std.net.Server, config: Config) !void {
-        var events: [512]std.posix.system.epoll_event = undefined;
+        var events: [1024]std.posix.system.epoll_event = undefined;
         
         // Short timeout for responsiveness
-        const num_events = std.posix.system.epoll_wait(self.poller_fd, &events, 512, 50); // 50ms
+        const num_events = std.posix.system.epoll_wait(self.poller_fd, &events, 1024, 10); // 10ms
         
         if (num_events < 0) return error.EpollWaitFailed;
         if (num_events == 0) return; // Timeout


### PR DESCRIPTION
This pull request improves the performance and responsiveness of the event loops in the `UltraPoller` struct by increasing the event buffer size and reducing the timeout duration for both macOS (kqueue) and Linux (epoll) implementations.

### Event loop performance improvements:

* **Kqueue event loop (macOS)**:  
  - Increased the event buffer size from 512 to 1024 to handle more simultaneous events.  
  - Reduced the timeout duration from 50ms to 10ms for faster responsiveness.  
  (`src/main.zig`, [src/main.zigL426-R431](diffhunk://#diff-d924ca21d81d7d5a59eb9e10d3e2689c4c58a7e28e6ecce6a064701666f5a730L426-R431))

* **Epoll event loop (Linux)**:  
  - Increased the event buffer size from 512 to 1024 to handle more simultaneous events.  
  - Reduced the timeout duration from 50ms to 10ms for faster responsiveness.  
  (`src/main.zig`, [src/main.zigL448-R451](diffhunk://#diff-d924ca21d81d7d5a59eb9e10d3e2689c4c58a7e28e6ecce6a064701666f5a730L448-R451))