### PR TITLE
docs: update README with latest performance metrics and memory usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ## ✨ Features
 
-- 🪶 **Ultra-lightweight** - Binary size <70KB (ReleaseSmall) or <100KB (ReleaseFast)
+- 🪶 **Ultra-lightweight** - Binary size 73KB (ReleaseSmall) or 98KB (ReleaseFast)
 - 🔗 **Zero dependencies** - Uses only Zig standard library
 
 - 🌐 **Cross-platform** - Supports macOS/Linux (Windows currently unsupported)
@@ -90,7 +90,7 @@ zig build test-integration   # Run integration tests only
 
 # Minimal binary size for embedded/Docker
 zig build -Doptimize=ReleaseSmall
-./zig-out/bin/ezserve --root ./public  # Only 68KB!
+./zig-out/bin/ezserve --root ./public  # Only 73KB!
 
 ```
 
@@ -123,7 +123,7 @@ zig build -Doptimize=ReleaseSmall
 - [x] **Comprehensive test suite** - Unit and integration tests
 - [x] **Multi-threading support** - Configurable worker threads with `--threads`
 - [x] **Queue-based architecture** - Eliminates socket errors and race conditions
-- [x] **Binary size optimization** - ReleaseSmall (68KB) vs ReleaseFast (99KB)
+- [x] **Binary size optimization** - ReleaseSmall (73KB) vs ReleaseFast (98KB)
 
 ### 🔮 Future Enhancements
 
@@ -184,20 +184,28 @@ Compatible with popular log aggregation tools:
 
 ## 📈 Performance
 
+### Latest Benchmark Results
+
 | Metric | ReleaseSmall | ReleaseFast |
 |--------|--------------|-------------|
-| Binary size | 68KB | 99KB |
-| Memory usage | <5MB | <5MB |
+| Binary size | 73KB | 98KB |
+| Memory usage | ~600KB RSS | ~600KB RSS |
 | Startup time | <50ms | <50ms |
-| Throughput | ~1600 req/s | ~1800 req/s |
-| Read errors | <100 (0.5%) | <80 (0.4%) |
+| Throughput (10s test) | 1,626 req/s | 1,634 req/s |
+| Peak performance | 3,255 req/s | 3,221 req/s |
+| Read errors | <20 (0.1%) | <25 (0.15%) |
 | Concurrent connections | Up to system limits | Up to system limits |
+
+### Test Environment
+- **Platform**: macOS (Apple Silicon)  
+- **Test tool**: wrk (4 threads, 100 connections)
+- **Architecture**: UltraPoller with queue-based multi-threading
 
 ## 🆚 Comparison with Other Tools
 
 | Tool | Binary Size | Dependencies | Startup Time | Features |
 |------|-------------|--------------|--------------|----------|
-| **ezserve** | 68KB-99KB | Zero | <50ms | Zig-based, dev mode, multi-threading |
+| **ezserve** | 73KB-98KB | Zero | <50ms | Zig-based, dev mode, multi-threading |
 | Python http.server | ~50MB | Python | ~200ms | Built-in standard |
 | Node.js http-server | ~30MB | Node.js | ~300ms | Via npm |
 | Go net/http | ~10MB | Zero | ~100ms | Static binary |
@@ -209,10 +217,10 @@ Compatible with popular log aggregation tools:
 # Development build (includes file watching and browser auto-open)
 zig build
 
-# Performance optimized build (99KB, max speed)
+# Performance optimized build (98KB, max speed)
 zig build -Doptimize=ReleaseFast
 
-# Size optimized build (68KB, good speed)
+# Size optimized build (73KB, good speed)
 zig build -Doptimize=ReleaseSmall
 
 # Cross-compilation examples


### PR DESCRIPTION
This pull request updates the documentation in `README.md` to reflect the latest binary size, performance benchmarks, and test environment details for the `ezserve` project. The changes ensure that the information is accurate and up-to-date.

### Updates to binary size and performance metrics:

* Updated binary size details across various sections to reflect the latest measurements: `ReleaseSmall` is now 73KB (previously 68KB), and `ReleaseFast` is now 98KB (previously 99KB). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L19-R19) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L93-R93) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L126-R126) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L212-R223)
* Added a new "Latest Benchmark Results" section with detailed metrics, including throughput, peak performance, and memory usage. Memory usage is now specified as ~600KB RSS, and throughput details have been updated with more granular results.

### Additional documentation improvements:

* Included a "Test Environment" subsection under the performance section, specifying platform, test tool, and architecture details for benchmarking.