### PR TITLE
disable: CodeQL workflow for Zig projects

### DIFF
--- a/.github/workflows/codeql.yml.disabled
+++ b/.github/workflows/codeql.yml.disabled
@@ -1,12 +1,10 @@
 name: "CodeQL"
 
 on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+  # Disable CodeQL for Zig projects - not supported
   schedule:
     - cron: '0 6 * * 1'  # Weekly on Monday at 6 AM UTC
+  workflow_dispatch:  # Manual trigger only
 
 jobs:
   analyze:


### PR DESCRIPTION
Zig is not supported by CodeQL (only C/C++, JavaScript, Python, etc.) Renamed workflow file to .disabled to prevent failures

🤖 Generated with [Claude Code](https://claude.ai/code)