### PR TITLE
Fix/docker build zig download

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest] # Windows未サポート
-        zig-version: ['0.14.1']
+        zig-version: ['0.14.0']
     
     steps:
     - uses: actions/checkout@v4
@@ -86,7 +86,7 @@ jobs:
     - name: Setup Zig
       uses: goto-bus-stop/setup-zig@v2
       with:
-        version: 0.14.1
+        version: 0.14.0
     
     - name: Build for ${{ matrix.target }}
       run: timeout 300 zig build -Doptimize=ReleaseFast -Dtarget=${{ matrix.target }} || zig build -Doptimize=ReleaseSmall -Dtarget=${{ matrix.target }}
@@ -109,7 +109,7 @@ jobs:
     - name: Setup Zig
       uses: goto-bus-stop/setup-zig@v2
       with:
-        version: 0.14.1
+        version: 0.14.0
     
     - name: Install wrk
       run: |
@@ -252,7 +252,7 @@ jobs:
     - name: Setup Zig
       uses: goto-bus-stop/setup-zig@v2
       with:
-        version: 0.14.1
+        version: 0.14.0
     
     - name: Build with security checks
       run: zig build -Doptimize=ReleaseSafe
@@ -275,7 +275,7 @@ jobs:
     - name: Setup Zig
       uses: goto-bus-stop/setup-zig@v2
       with:
-        version: 0.14.1
+        version: 0.14.0
     
     - name: Build ReleaseFast
       run: |
@@ -326,7 +326,7 @@ jobs:
     - name: Setup Zig
       uses: goto-bus-stop/setup-zig@v2
       with:
-        version: 0.14.1
+        version: 0.14.0
     
     - name: Check code formatting
       run: |
@@ -350,7 +350,7 @@ jobs:
     - name: Setup Zig
       uses: goto-bus-stop/setup-zig@v2
       with:
-        version: 0.14.1
+        version: 0.14.0
     
     - name: Build server
       run: zig build -Doptimize=ReleaseSmall
@@ -401,8 +401,10 @@ jobs:
         RUN apk add --no-cache curl xz
         
         # Install Zig
-        RUN curl -L https://ziglang.org/download/0.14.1/zig-linux-x86_64-0.14.1.tar.xz | tar -xJ
-        ENV PATH="/zig-linux-x86_64-0.14.1:$PATH"
+        RUN curl -L -o zig.tar.xz https://ziglang.org/download/0.14.0/zig-linux-x86_64-0.14.0.tar.xz && \
+            tar -xJf zig.tar.xz && \
+            rm zig.tar.xz
+        ENV PATH="/zig-linux-x86_64-0.14.0:$PATH"
         
         WORKDIR /app
         COPY . .
@@ -446,7 +448,7 @@ jobs:
     - name: Setup Zig
       uses: goto-bus-stop/setup-zig@v2
       with:
-        version: 0.14.1
+        version: 0.14.0
     
     - name: Download all artifacts
       uses: actions/download-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -425,7 +425,7 @@ jobs:
         echo "<h1>Docker Test</h1>" > index.html
         
         # Run container
-        docker run -d --name ezserve-test -p 8091:8000 -v "$(pwd):/app" ezserve:latest --root /app
+        docker run -d --name ezserve-test -p 8091:8000 -v "$(pwd):/app" ezserve:latest --root /app --bind 0.0.0.0
         sleep 2
         
         # Test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM alpine:latest AS builder
+RUN apk add --no-cache curl xz
+
+# Install Zig
+RUN curl -L -o zig.tar.xz https://ziglang.org/download/0.14.0/zig-linux-x86_64-0.14.0.tar.xz && \
+    tar -xJf zig.tar.xz && \
+    rm zig.tar.xz
+ENV PATH="/zig-linux-x86_64-0.14.0:$PATH"
+
+WORKDIR /app
+COPY . .
+RUN zig build -Doptimize=ReleaseSmall
+
+FROM scratch
+COPY --from=builder /app/zig-out/bin/ezserve /ezserve
+EXPOSE 8000
+ENTRYPOINT ["/ezserve"]
+EOF < /dev/null


### PR DESCRIPTION
This pull request primarily downgrades the Zig compiler version used in the CI pipeline and Dockerfile from `0.14.1` to `0.14.0`, and introduces a new multi-stage `Dockerfile`. Additionally, it updates the Docker container run command to include a new binding option.

### Zig version downgrade:
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL38-R38): Changed the Zig version from `0.14.1` to `0.14.0` across multiple steps in the CI pipeline, including setup and build steps. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL38-R38) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL89-R89) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL112-R112) [[4]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL255-R255) [[5]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL278-R278) [[6]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL329-R329) [[7]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL353-R353) [[8]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL449-R451)
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL404-R407): Updated the Zig installation command to download and extract version `0.14.0` instead of `0.14.1`.

### Dockerfile updates:
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R1-R18): Introduced a new multi-stage build process. The first stage installs Zig `0.14.0` and builds the application, while the second stage creates a minimal container with the built binary.

### Docker container run command:
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL426-R428): Modified the `docker run` command to include the `--bind 0.0.0.0` option, ensuring the server binds to all network interfaces.